### PR TITLE
export c4query_setParameters

### DIFF
--- a/C/c4.def
+++ b/C/c4.def
@@ -106,6 +106,7 @@ c4query_columnCount
 c4query_columnTitle
 c4query_run
 c4query_explain
+c4query_setParameters
 
 c4blob_keyFromString
 c4blob_keyToString

--- a/C/c4.exp
+++ b/C/c4.exp
@@ -104,6 +104,7 @@ _c4query_columnCount
 _c4query_columnTitle
 _c4query_run
 _c4query_explain
+_c4query_setParameters
 
 _c4blob_keyFromString
 _c4blob_keyToString

--- a/C/c4.gnu
+++ b/C/c4.gnu
@@ -105,6 +105,7 @@
 		c4query_columnTitle;
 		c4query_run;
 		c4query_explain;
+		c4query_setParameters;
 
 		c4blob_keyFromString;
 		c4blob_keyToString;


### PR DESCRIPTION
This exposes one additional symbol, the c4query_setParameters function.
This is used for an upcoming PR on couchbase-lite-rust to allorw n1ql queries (with json parameters), but probably isn't useful until the other one is ready.

PRs on repositories with git submodules sure aren't easy !